### PR TITLE
Adjusting quickstart steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
 <img src="images/logo.png" width="700" align="center">
 <br/>
 
-
 Autologger is a friction log generator tool.
 
 ## How it works
 
 ![Workflow](images/workflow.png)
 
-## Quickstart 
+## Quickstart
 
-*Note: This is an early prototype. It was tested on local MacOS Sonoma, using an external Drive test account.* 
+_Note: This is an early prototype. It was tested on local MacOS Sonoma, using an external Drive test account._
 
-1. Clone repo. 
-2. `cd autologger/src/` 
-3. `python3 -m venv venv` 
+1. Clone repo.
+2. `cd autologger/src/`
+3. `python3 -m venv venv`
 4. `source venv/bin/activate`
 5. `pip install -r requirements.txt`
-6. Download Google Meet recording of a friction log session. 
+6. Download Google Meet recording of a friction log session.
 7. Get Google Workspace OAuth client ID credentials by following [these instructions](https://developers.google.com/workspace/guides/create-credentials#oauth-client-id). Save to `src/credentials.json`.
-8. Edit `config.ini` with your info. 
-9.  Run `python autologger.py`. 
-10. Get the output Markdown file in the `output/` directory. Copy the contents.  
-11. Open a new Google Doc. 
-12. Click Edit > Paste as Markdown. 
+8. Edit `config.ini` with your info.
+9. Run `python autologger.py`.
+10. Get the output Markdown file in the `output/` directory. Copy the contents.
+11. Open a new Google Doc.
+12. Click Edit > Paste as Markdown.
 
-## Sources 
+## Sources
+
 - [Moviepy](https://pypi.org/project/moviepy/)
-- [Mdutils)](https://pypi.org/project/mdutils/)
-- [Gemini on Vertex AI - Python SDK](https://cloud.google.com/vertex-ai/generative-ai/docs/start/quickstarts/quickstart-multimodal) 
+- [Mdutils](https://pypi.org/project/mdutils/)
+- [Gemini on Vertex AI - Python SDK](https://cloud.google.com/vertex-ai/generative-ai/docs/start/quickstarts/quickstart-multimodal)
 - [ASCII art](https://patorjk.com/software/taag/#p=display&h=2&v=2&f=Modular&t=autologger)
 - [Robot emoji](https://emoji.supply/kitchen/?%F0%9F%98%A1+%F0%9F%A4%96=8ww1kx)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Autologger is a friction log generator tool.
 4. `source venv/bin/activate`
 5. `pip install -r requirements.txt`
 6. Download Google Meet recording of a friction log session. 
-7. Get Google Drive/Docs OAuth `credentials.json` by following [these instructions](). Save to `src/`.
+7. Get Google Workspace OAuth client ID credentials by following [these instructions](https://developers.google.com/workspace/guides/create-credentials#oauth-client-id). Save to `src/credentials.json`.
 8. Edit `config.ini` with your info. 
 9.  Run `python autologger.py`. 
 10. Get the output Markdown file in the `output/` directory. Copy the contents.  

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Autologger is a friction log generator tool.
 
 1. Clone repo. 
 2. `cd autologger/src/` 
-3. `python3 -m venv .` 
-4. `source bin/activate`
+3. `python3 -m venv venv` 
+4. `source venv/bin/activate`
 5. `pip install -r requirements.txt`
 6. Download Google Meet recording of a friction log session. 
 7. Get Google Drive/Docs OAuth `credentials.json` by following [these instructions](). Save to `src/`.

--- a/src/autologger.py
+++ b/src/autologger.py
@@ -227,6 +227,12 @@ def autologger():
     configFilePath = "config.ini"
     config.read(configFilePath)
 
+
+    # create output directories if they don't exist
+    directories = ['./clips', './out']
+    for directory in directories:
+        os.makedirs(directory, exist_ok=True)
+
     video_path = config["autologger"]["video_path"]
     video_path = video_path.strip()
     topic = video_path.split("/")[-1].split(".")[0]

--- a/src/config.ini
+++ b/src/config.ini
@@ -1,7 +1,7 @@
 [autologger]
-video_path=/Users/mokeefe/dev/autologger/src/input/java_cr.mp4
+video_path=/PATH/TO/VIDEO.mp4
 summary_interval_secs=60
-gcp_project_id=cpet-vcy
-gcs_bucket_name=cpet-autologger-test
+gcp_project_id=PROJECT_ID
+gcs_bucket_name=GCS_BUCKET_NAME
 vertexai_model=gemini-1.5-pro-preview-0514
 system_instructions=You are an automated Friction Log generator. Your job is to take a recording or transcript, and summarize the developer's journey on a specific task: each step, with the highs and lows (sentiment) of their experience. The topic is deploying a Java app to Google Cloud Run.

--- a/src/pyvenv.cfg
+++ b/src/pyvenv.cfg
@@ -1,5 +1,0 @@
-home = /opt/homebrew/opt/python@3.11/bin
-include-system-site-packages = false
-version = 3.11.7
-executable = /opt/homebrew/Cellar/python@3.11/3.11.7/Frameworks/Python.framework/Versions/3.11/bin/python3.11
-command = /opt/homebrew/opt/python@3.11/bin/python3.11 -m venv /Users/mokeefe/dev/autologger/src


### PR DESCRIPTION
I ran through the quickstart and made some adjustments along the way:
- change step to create venv in a subdirectory instead of cwd 
- add link to oauth instructions
- templatized `config.ini`
- have` autologger()` create `clips/` and `out/` if they don't exist

Fixes #2 