### PR TITLE
use raw string literal

### DIFF
--- a/src/autologger.py
+++ b/src/autologger.py
@@ -212,7 +212,7 @@ def autologger():
         level=logging.DEBUG, format="%(levelname)s:%(name)s:%(message)s"
     )
     logging.info(
-        """
+        r"""
              _        _                             
             | |      | |                            
   __ _ _   _| |_ ___ | | ___   __ _  __ _  ___ _ __ 


### PR DESCRIPTION
Use a raw string literal for autologger banner to prevent "Invalid escape sequence" error

Fixes #10 