### PR TITLE
uncomment "split video" method call

### DIFF
--- a/src/autologger.py
+++ b/src/autologger.py
@@ -255,7 +255,7 @@ def autologger():
     )
     fl = MdUtils(file_name="out/" + topic, title=topic)
 
-    # split_video_and_grab_screenshots(video_path, interval)
+    split_video_and_grab_screenshots(video_path, interval)
 
     clips = []
     subdirs = os.listdir("./clips")


### PR DESCRIPTION
This method executes step #5 as seen in the README. It was commented out. I think it needs to be uncommented.